### PR TITLE
Add Python 3 compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,19 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
+and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+
+## Unreleased
+
+### Added
+
+- Python 3.5, 3.6, 3.7 support
+
+### Removed
+
+- Using more than one context manager in `with_` decorator is not possible anymore.
+- Python 2.5, 2.6 support
+
+## 0.1.16 - 2017-01-09

--- a/abl/__init__.py
+++ b/abl/__init__.py
@@ -1,3 +1,2 @@
-#__import__('pkg_resources').declare_namespace(__name__)
 from pkgutil import extend_path
 __path__ = extend_path(__path__, __name__)

--- a/abl/util/lockfile.py
+++ b/abl/util/lockfile.py
@@ -39,8 +39,8 @@ class LockFile(object):
 
         try:
             self.fd = os.open(self.name, os.O_WRONLY | os.O_CREAT | os.O_APPEND)
-        except OSError, e:
-            if e[0] == errno.ENOENT:
+        except OSError as e:
+            if e.errno == errno.ENOENT:
                 raise LockFileCreationException(e)
             else:
                 raise
@@ -59,9 +59,9 @@ class LockFile(object):
                 msvcrt.locking(self.file.fileno(), lock_flags, 1)
             else:
                 fcntl.flock(self.file, lock_flags)
-        except IOError, e:
+        except IOError as e:
             error_code = errno.EACCES if is_windows else errno.EAGAIN
-            if e[0] == error_code:
+            if e.errno == error_code:
                 raise LockFileObtainException()
             raise
 
@@ -79,6 +79,6 @@ class LockFile(object):
         if self.cleanup:
             try:
                 os.remove(self.name)
-            except OSError, e:
-                if e[0] != errno.ENOENT:
+            except OSError as e:
+                if e.errno != errno.ENOENT:
                     raise

--- a/abl/util/memoization.py
+++ b/abl/util/memoization.py
@@ -1,7 +1,6 @@
 from collections import defaultdict
 from functools import partial
 
-#==============================================================================
 
 # A dict with scopes as keys and lists of memoized objects as values.
 MEMOIZED = defaultdict(list)
@@ -42,11 +41,11 @@ def memoized(scope='global'):
             if instance is not None:
                 return partial(self.__call__, instance)
             return self
-                
+
 
         def __repr__(self):
-            """Return the function's docstring."""
-            return self._func.__doc__
+            """Return the function's docstring or name."""
+            return self._func.__doc__ or self._func.__name__
 
 
         def clear_cache(self):
@@ -85,4 +84,3 @@ def memoized(scope='global'):
         raise Exception('"memoized"-decorator was not called on initialization.')
 
     return Memoized
-

--- a/setup.py
+++ b/setup.py
@@ -11,17 +11,15 @@ versioneer.parentdir_prefix = "abl.util"
 TEST_REQUIREMENTS = ["nose"]
 
 setup(
-    name = "abl.util",
-    version = versioneer.get_version(),
-    cmdclass = versioneer.get_cmdclass(),
-    author = "Diez B. Roggisch",
-    author_email = "diez.roggisch@ableton.com",
-    description = "A package that contains various helpful classes and functions used widely in the Ableton Python code base.",
+    name="abl.util",
+    version=versioneer.get_version(),
+    cmdclass=versioneer.get_cmdclass(),
+    author="Diez B. Roggisch",
+    author_email="diez.roggisch@ableton.com",
+    description="A package that contains various helpful classes and functions used widely in the Ableton Python code base.",
     license="MIT",
+    url="https://github.com/AbletonAG/abl.util",
     packages=find_packages(exclude=['test']),
-    #namespace_packages = ["abl"],
-    install_requires = [
-        ],
     extras_require = dict(
         testing=TEST_REQUIREMENTS,
         ),
@@ -31,6 +29,8 @@ setup(
         'License :: OSI Approved :: MIT License',
         'Operating System :: OS Independent',
         'Programming Language :: Python',
+        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3.6',
         'Intended Audience :: Developers',
         'Topic :: Utilities',
     ],

--- a/test/test_lockfile.py
+++ b/test/test_lockfile.py
@@ -1,96 +1,87 @@
-from __future__ import with_statement
+from multiprocessing import Process, Queue
+from unittest import TestCase
+import tempfile
 
-try:
-    from multiprocessing import Process, Queue
-except ImportError:
-    print "This test needs the module multiprocessing."
-    print "Please either use python >= 2.6 or install it."
-else:
-    from unittest import TestCase
-    import tempfile
-    import time
-
-    from abl.util import LockFile, LockFileObtainException
+from abl.util import LockFile, LockFileObtainException
 
 
-    def locker(q, r):
-        lock_file_name = q.get()
-        with LockFile(lock_file_name):
-            r.put("locked")
-            while True:
-                command = q.get()
-                if command == "unlock":
-                    break
+def locker(q, r):
+    lock_file_name = q.get()
+    with LockFile(lock_file_name):
+        r.put("locked")
+        while True:
+            command = q.get()
+            if command == "unlock":
+                break
 
 
 
-    def failer(fname, r):
-        try:
-            with LockFile(fname, fail_on_lock=True):
-                pass
-        except LockFileObtainException:
-            r.put("failed properly")
-        except:
-            r.put("something else went wrong")
-
-
-    def waiter(fname, q, r):
+def failer(fname, r):
+    try:
         with LockFile(fname, fail_on_lock=True):
-            r.put("got lock")
-            # just wait until something happens
-            q.get()
+            pass
+    except LockFileObtainException:
+        r.put("failed properly")
+    except Exception as error:
+        r.put("something else went wrong: {}".format(error))
 
 
-    class LockFileTests(TestCase):
+def waiter(fname, q, r):
+    with LockFile(fname, fail_on_lock=True):
+        r.put("got lock")
+        # just wait until something happens
+        q.get()
 
 
-        def test_lock_with_fail(self):
-            q = Queue()
-            r = Queue()
-            locker_p = Process(target=locker, args=(q,r))
-            locker_p.start()
-            fname = tempfile.mktemp()
-            q.put(fname)
-            # wait until the locker really has the lock
-            assert r.get() == "locked"
-            # now start the failer
-            failer_p = Process(target=failer, args=(fname, r))
-            failer_p.start()
+class LockFileTests(TestCase):
 
-            failer_result = r.get()
-            assert failer_result == "failed properly", failer_result
+    def test_lock_with_fail(self):
+        q = Queue()
+        r = Queue()
+        locker_p = Process(target=locker, args=(q,r))
+        locker_p.start()
+        fname = tempfile.mktemp()
+        q.put(fname)
+        # wait until the locker really has the lock
+        self.assertEqual(r.get(), "locked")
+        # now start the failer
+        failer_p = Process(target=failer, args=(fname, r))
+        failer_p.start()
+
+        failer_result = r.get()
+        try:
+            self.assertEqual(failer_result, "failed properly")
+        finally:
             # make the locker release it's lock
             q.put("unlock")
 
+    def test_lock_with_wait(self):
+        q = Queue()
+        r = Queue()
+        locker_p = Process(target=locker, args=(q,r))
+        locker_p.start()
+        fname = tempfile.mktemp()
+        q.put(fname)
+        # wait until the locker really has the lock
+        self.assertEqual(r.get(), "locked")
+        # now start the waiter
+        waiter_p = Process(target=waiter, args=(fname, q, r))
+        waiter_p.start()
 
-        def test_lock_with_wait(self):
-            q = Queue()
-            r = Queue()
-            locker_p = Process(target=locker, args=(q,r))
-            locker_p.start()
-            fname = tempfile.mktemp()
-            q.put(fname)
-            # wait until the locker really has the lock
-            assert r.get() == "locked"
-            # now start the waiter
-            waiter_p = Process(target=waiter, args=(fname, q, r))
-            waiter_p.start()
+        # now make the locker release the lock
+        q.put("unlock")
 
-            # now make the locker release the lock
-            q.put("unlock")
+        # this means the waiter should have it
+        waiter_result = r.get()
+        self.assertEqual(waiter_result, "got lock")
 
-            # this means the waiter should have it
-            waiter_result = r.get()
-            assert waiter_result == "got lock", waiter_result
+        # and the failer should still fail, that poor fella
+        failer_p = Process(target=failer, args=(fname, r))
+        failer_p.start()
 
-            # and the failer should still fail, that poor fella
-            failer_p = Process(target=failer, args=(fname, r))
-            failer_p.start()
-
-            failer_result = r.get()
-            assert failer_result == "failed properly", failer_result
-
+        failer_result = r.get()
+        try:
+            self.assertEqual(failer_result, "failed properly")
+        finally:
             # now let the waiter terminate
             q.put("whatever")
-
-

--- a/test/test_memoization.py
+++ b/test/test_memoization.py
@@ -28,7 +28,7 @@ class MemoizationTests(TestCase):
     def test_memoization_fails_gracefully_on_non_hashable_arguments(self):
         global COUNTER
         COUNTER = 0
-        
+
         @memoized()
         def test(arg):
             global COUNTER
@@ -44,7 +44,7 @@ class MemoizationTests(TestCase):
     def test_memoization_doesnt_mask_exceptions(self):
         global COUNTER
         COUNTER = 0
-        
+
         @memoized()
         def test():
             global COUNTER
@@ -54,10 +54,10 @@ class MemoizationTests(TestCase):
         self.failUnlessRaises(TypeError, test)
         # we are only called *once*
         assert COUNTER == 1
-        
+
 
         COUNTER = 0
-        
+
         @memoized()
         def test():
             global COUNTER
@@ -67,7 +67,7 @@ class MemoizationTests(TestCase):
         self.failUnlessRaises(KeyError, test)
         # we are only called *once*
         assert COUNTER == 1
-        
+
 
     def test_clearing_memoization_cache(self):
         global COUNTER
@@ -98,13 +98,13 @@ class MemoizationTests(TestCase):
         assert test_two() == 5
         assert test() == 4
         assert test_two() == 5
-        
-        
-        
+
+
+
     def test_memoization_on_objects(self):
         global COUNTER
         COUNTER = 0
-        
+
         class Test(object):
 
 
@@ -131,12 +131,12 @@ class MemoizationTests(TestCase):
         assert b.test_method() == 2
         assert a.test_classmethod() == 3
         assert b.test_classmethod() == 3
-        
+
 
     def test_scope_isolation(self):
         global COUNTER
         COUNTER = 0
-        
+
         @memoized("foo")
         def test_foo():
             global COUNTER

--- a/test/test_misc.py
+++ b/test/test_misc.py
@@ -1,10 +1,7 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import with_statement
-
 import tempfile, os
 from unittest import TestCase
-
 
 from abl.util import (
     SafeModifier,
@@ -18,7 +15,6 @@ from abl.util import (
 
 
 class TestMisc(TestCase):
-
 
     def test_classproperty(self):
 
@@ -36,7 +32,7 @@ class TestMisc(TestCase):
 
 
     def test_partition(self):
-        self.assertEqual(partition(lambda i: i < 5, xrange(10)),
+        self.assertEqual(partition(lambda i: i < 5, range(10)),
                          ([0, 1, 2, 3, 4], [5, 6, 7, 8, 9]))
 
 
@@ -47,12 +43,16 @@ class TestUnicodify(TestCase):
         assert unicodify(utest) is utest
 
     def test_utf8_to_unicode(self):
-        teststring = 'H\xc3\xbclle'
-        assert unicodify(teststring) == u"Hülle"
+        teststring = b'H\xc3\xbclle'
+        self.assertEqual(unicodify(teststring), u"Hülle")
+
+    def test_latin1_to_unicode(self):
+        teststring = b'H\xfclle'
+        self.assertEqual(unicodify(teststring), u"Hülle")
 
     def test_ignore_errors(self):
-        teststring = 'H\xc3\xbclle'
-        assert unicodify(teststring, codecs=()) == u"Hlle"
+        teststring = b'H\xc3\xbclle'
+        self.assertEqual(unicodify(teststring, codecs=()), u"Hlle")
 
 
 class FixpointTests(TestCase):
@@ -97,9 +97,7 @@ class WithDecoratorTests(TestCase):
     class Foo(object):
         pass
 
-
     def test_decorate_function(self):
-
         foo = self.Foo()
         foo.bar = 42
 
@@ -110,7 +108,6 @@ class WithDecoratorTests(TestCase):
 
         decorated(1)
         self.assertEqual(foo.bar, 42)
-
 
     def test_decorate_method(self):
 
@@ -127,28 +124,7 @@ class WithDecoratorTests(TestCase):
         self.assertEqual(foo.bar, 42)
 
 
-    def test_decorate_many(self):
-
-        foo = self.Foo()
-        foo.bar = 42
-        foo.foo = 20
-
-        class MethodDecorationTest(object):
-            @with_(SafeModifier(foo, 'bar', 13), SafeModifier(foo, 'foo', 2))
-            def decorated(self, x):
-                assert x == 1
-                assert foo.bar == 13
-                assert foo.foo == 2
-
-        MethodDecorationTest().decorated(1)
-        self.assertEqual(foo.bar, 42)
-        self.assertEqual(foo.foo, 20)
-
-
-
-
 class TestWorkingDirectory(TestCase):
-
 
     def test_working_directory(self):
         td = tempfile.mkdtemp()

--- a/test/test_streams.py
+++ b/test/test_streams.py
@@ -1,4 +1,3 @@
-from __future__ import with_statement
 import tempfile
 
 from unittest import TestCase
@@ -53,8 +52,8 @@ class TestStreams(TestCase):
             bs.seek(10)
             assert bs.tell() == 10
             assert bs.read(300) == testdata[10:10 + 300]
-            
-            
+
+
         # seek into the buffer,
         # then read a chunk over it's size
         with open(tf) as inf:
@@ -68,7 +67,7 @@ class TestStreams(TestCase):
             assert bs.read(1000) == testdata[30:1000 + 30]
             assert bs.tell() == 1030
 
-        
+
         # read the last character out of the
         # buffer. That caused an error at some time.
         with open(tf) as inf:
@@ -78,5 +77,5 @@ class TestStreams(TestCase):
             bs.seek(99)
             assert bs.read(1) == testdata[99]
 
-        
-            
+
+


### PR DESCRIPTION
Change syntax to be compatible with both Python 2 and 3.

Simplify `with_` because this depends on the [deprecated `nested` function](https://docs.python.org/2/library/contextlib.html#contextlib.nested) which doesn't exist for Python 3. Using multiple context managers is not so useful to begin with - you could always decorate a method multiple times.

Tests pass with Python 2.7 and 3.6.